### PR TITLE
feat: restore configure time project extension function and adapt test

### DIFF
--- a/integration-token/build.gradle.kts
+++ b/integration-token/build.gradle.kts
@@ -11,7 +11,15 @@ vault {
     maxRetries.set(2)
     retryIntervalMilliseconds.set(200)
 }
+val configTimeSecrets: Map<String, String> = vault("secret/example")
 tasks {
+    val needsSecretsConfigTime by creating {
+        doLast {
+            if (configTimeSecrets["examplestring"] != "helloworld") throw kotlin.IllegalStateException("examplestring couldn't be read")
+            if (configTimeSecrets["exampleint"]?.toInt() != 1337) throw kotlin.IllegalStateException("exampleint couldn't be read")
+            println("getting secrets succeeded!")
+        }
+    }
     val needsSecrets by creating(GetVaultSecretTask::class) {
         secretPath.set("secret/example")
         doLast {
@@ -27,6 +35,6 @@ tasks {
         }
     }
     val build by existing {
-        dependsOn(needsSecrets, fromBuildSrc)
+        dependsOn(needsSecretsConfigTime, needsSecrets, fromBuildSrc)
     }
 }

--- a/src/main/kotlin/com/liftric/vault/VaultClientPlugin.kt
+++ b/src/main/kotlin/com/liftric/vault/VaultClientPlugin.kt
@@ -24,3 +24,22 @@ fun Project.vault(): VaultClientExtension {
     return extensions.getByName(extensionName) as? VaultClientExtension
         ?: throw IllegalStateException("$extensionName is not of the correct type")
 }
+
+fun Project.vault(secretPath: String): Map<String, String> {
+    val extension: VaultClientExtension = vault()
+    val token = GetVaultSecretTask.determineToken(
+        vaultToken = extension.vaultToken.orNull,
+        vaultTokenFilePath = extension.vaultTokenFilePath.orNull
+    )
+    val address = GetVaultSecretTask.determinAddress(vaultAddress = extension.vaultAddress.orNull)
+    val maxRetries = extension.maxRetries.getOrElse(Defaults.MAX_RETRIES)
+    val retryIntervalMilliseconds = extension.retryIntervalMilliseconds.getOrElse(Defaults.RETRY_INTERVAL_MILLI)
+    println("[vault] getting `$secretPath` from $address")
+
+    return VaultClient(
+        token = token,
+        vaultAddress = address,
+        maxRetries = maxRetries,
+        retryIntervalMilliseconds = retryIntervalMilliseconds
+    ).get(secretPath)
+}


### PR DESCRIPTION
Restore old configuration time secret fetching. In some cases (notably the gradle android plugin) it's impossible to use the lazy task approach, even calling execute manually on config time won't work.